### PR TITLE
Scramble root pw before creating user

### DIFF
--- a/cloudbaseinit/plugins/factory.py
+++ b/cloudbaseinit/plugins/factory.py
@@ -23,9 +23,9 @@ opts = [
         'plugins',
         default=[
         'cloudbaseinit.plugins.freebsd.sethostname.SetHostNamePlugin',
+        'cloudbaseinit.plugins.freebsd.scramblerootpassword.ScrambleRootPassword',
         'cloudbaseinit.plugins.freebsd.createuser.CreateUserPlugin',
         'cloudbaseinit.plugins.freebsd.setuserpassword.SetUserPasswordPlugin',
-        'cloudbaseinit.plugins.freebsd.scramblerootpassword.ScrambleRootPassword',
         'cloudbaseinit.plugins.freebsd.enlargeroot.EnlargeRoot',
         'cloudbaseinit.plugins.freebsd.networkconfig.NetworkConfigPlugin',
         'cloudbaseinit.plugins.freebsd.sshpublickeys.'


### PR DESCRIPTION
If I want to use the root username instead of "freebsd" I cannot set the password because it is scrambled afterwards. Changing the order allows the root password to be set.
