### PR TITLE
Pipe name servers to resolvconf rather than write them to resolv.conf

### DIFF
--- a/cloudbaseinit/osutils/freebsd.py
+++ b/cloudbaseinit/osutils/freebsd.py
@@ -3,6 +3,7 @@ from cloudbaseinit.osutils import base
 from subprocess import CalledProcessError
 import subprocess
 import datetime
+import os
 import os.path
 
 class FreeBSDUtils(base.BaseOSUtils):
@@ -78,7 +79,7 @@ class FreeBSDUtils(base.BaseOSUtils):
         if_cmd = 'ifconfig ' + adapter_name + ' inet ' + address + ' netmask ' + netmask + ' broadcast ' + broadcast
         route_cmd = 'route add default ' + gateway
         resolv_conf = ['domain ' + dnsdomain]
-        resolv_conf_file = open('/etc/resolv.conf', 'w')
+        resolv_conf_file = os.popen('resolvconf -a vtnet0', 'w', 1)
         for i in dnsnameservers:
             resolv_conf.append('nameserver ' + i)
 


### PR DESCRIPTION
i don't ever use this openstack cloud stuff or whatever so if theres some mode or code path where this is making an offline image or something watch out this may break it but if this runs for you as straightforward as it looked and worked for me then great, i was in the neighborhood and a little birdie told me you needed this so try it out and let me know what you think